### PR TITLE
fix: Calling run on a Piece would always return undefined in Router#runPaths

### DIFF
--- a/src/Router/Piece.js
+++ b/src/Router/Piece.js
@@ -57,9 +57,15 @@ class Piece {
 			await this._condition(request, response, options) :
 			true;
 
-		if (shouldRun) this._callback(request, response, options);
-		else if (this._onInhibit) this._onInhibit(request, response, options);
-		else response.end();
+		if (shouldRun) {
+			this._callback(request, response, options);
+			return true;
+		} else if (this._onInhibit) {
+			this._onInhibit(request, response, options);
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/src/Router/Piece.js
+++ b/src/Router/Piece.js
@@ -51,6 +51,7 @@ class Piece {
 	 * @param {Request} request The request
 	 * @param {Response} response The response
 	 * @param {*} options The options
+	 * @returns {boolean}
 	 */
 	async run(request, response, options) {
 		const shouldRun = this._condition ?

--- a/src/Router/Piece.js
+++ b/src/Router/Piece.js
@@ -64,9 +64,8 @@ class Piece {
 		} else if (this._onInhibit) {
 			this._onInhibit(request, response, options);
 			return true;
-		} else {
-			return false;
 		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
If you'd run the test example, you'll see that in the example test server, the response.end("Hello!") will ALWAYS run, even if you have added a handler for it. That is because Piece#run doesn't return a boolean.
This fixes that, by always returning a boolean value from run, making runPaths actually return a value that is used in the if check